### PR TITLE
Fix license

### DIFF
--- a/satysfi-fonts-asana-math.opam
+++ b/satysfi-fonts-asana-math.opam
@@ -9,7 +9,7 @@ This package installs fonts from http://mirrors.ctan.org/fonts/Asana-Math/.
 """
 maintainer: "MURASE Yuito <yuito.murase@gmail.com>"
 authors: "MURASE Yuito <yuito.murase@gmail.com>"
-license: "OFL"
+license: "OFL-1.1"
 homepage: "https://github.com/zeptometer/SATySFi-fonts-asana-math"
 bug-reports: "https://github.com/zeptometer/SATySFi-fonts-asana-math/issues"
 dev-repo: "git+https://github.com/zeptometer/SATySFi-fonts-asana-math.git"


### PR DESCRIPTION
Asana Math is licensed under OFL 1.1 (see https://ftp.jaist.ac.jp/pub/CTAN/fonts/Asana-Math/README)