### PR TITLE
Update package metadata for satysfi < 0.1

### DIFF
--- a/satysfi-fonts-asana-math-doc.opam
+++ b/satysfi-fonts-asana-math-doc.opam
@@ -14,7 +14,7 @@ dev-repo: "git+https://github.com/zeptometer/SATySFi-fonts-asana-math.git"
 depends: [
   "satysfi" {>= "0.0.4" & < "0.1.0"}
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
-  "satysfi-fonts-asana-math" {= "000.958+1+satysfi0.0.4"}
+  "satysfi-fonts-asana-math" {= "000.962+satysfi0.0.4"}
 ]
 build: [
   ["satyrographos" "opam" "build"

--- a/satysfi-fonts-asana-math-doc.opam
+++ b/satysfi-fonts-asana-math-doc.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "satysfi-fonts-asana-math-doc"
-version: "000.958ver1+satysfi0.0.4"
+version: "000.958+1+satysfi0.0.4"
 synopsis: "Document of SATySFi Font Package for Asana Math Fonts"
 description: """
 Document package for satysfi-fonts-asana-math
@@ -12,9 +12,9 @@ homepage: "https://github.com/zeptometer/SATySFi-fonts-asana-math"
 bug-reports: "https://github.com/zeptometer/SATySFi-fonts-asana-math/issues"
 dev-repo: "git+https://github.com/zeptometer/SATySFi-fonts-asana-math.git"
 depends: [
-  "satysfi" {>= "0.0.4" & < "0.0.5"}
+  "satysfi" {>= "0.0.4" & < "0.1.0"}
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
-  "satysfi-fonts-asana-math" {= "000.958ver1+satysfi0.0.4"}
+  "satysfi-fonts-asana-math" {= "000.958+1+satysfi0.0.4"}
 ]
 build: [
   ["satyrographos" "opam" "build"

--- a/satysfi-fonts-asana-math-doc.opam
+++ b/satysfi-fonts-asana-math-doc.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "satysfi-fonts-asana-math-doc"
-version: "000.958+1+satysfi0.0.4"
+version: "000.962+satysfi0.0.4"
 synopsis: "Document of SATySFi Font Package for Asana Math Fonts"
 description: """
 Document package for satysfi-fonts-asana-math

--- a/satysfi-fonts-asana-math.opam
+++ b/satysfi-fonts-asana-math.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "satysfi-fonts-asana-math"
-version: "000.958+1+satysfi0.0.4"
+version: "000.962+satysfi0.0.4"
 synopsis: "SATySFi Font Package for Asana Math Fonts"
 description: """
 SATySFi font package for Asana Math fonts.

--- a/satysfi-fonts-asana-math.opam
+++ b/satysfi-fonts-asana-math.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "satysfi-fonts-asana-math"
-version: "000.958ver1+satysfi0.0.4"
+version: "000.958+1+satysfi0.0.4"
 synopsis: "SATySFi Font Package for Asana Math Fonts"
 description: """
 SATySFi font package for Asana Math fonts.
@@ -21,7 +21,7 @@ extra-source "Asana-Math.otf" {
   ]
 }
 depends: [
-  "satysfi" {>= "0.0.4" & < "0.0.5"}
+  "satysfi" {>= "0.0.4" & < "0.1.0"}
   "satyrographos" {>= "0.0.2" & < "0.0.3"}
 ]
 build: []


### PR DESCRIPTION
## Summary
- bump the package version suffix to 000.958+1+satysfi0.0.4 to match the underlying archive
- relax the satysfi upper bound to <0.1.0 and align the doc package dependency

## Testing
- not run